### PR TITLE
use one awk call to parse Scoreboard string

### DIFF
--- a/zapache
+++ b/zapache
@@ -150,37 +150,37 @@ case "$CASE_VALUE" in
 	value="`awk '/^IdleWorkers:/ {print $2}' < \"$cache\"`"
 	rval=$?;;
 'WaitingForConnection')
-	value="`awk '/^Scoreboard:/ {print split($2,notused,"_")-1}' < \"$cache\"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"_")-1}' < \"$cache\"`"
 	rval=$?;;
 'StartingUp')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "S" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"S")-1}' < \"$cache\"`"
 	rval=$?;;
 'ReadingRequest')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "R" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"R")-1}' < \"$cache\"`"
 	rval=$?;;
 'SendingReply')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "W" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"W")-1}' < \"$cache\"`"
 	rval=$?;;
 'KeepAlive')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "K" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"K")-1}' < \"$cache\"`"
 	rval=$?;;
 'DNSLookup')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "D" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"D")-1}' < \"$cache\"`"
 	rval=$?;;
 'ClosingConnection')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "C" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"C")-1}' < \"$cache\"`"
 	rval=$?;;
 'Logging')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "L" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"L")-1}' < \"$cache\"`"
 	rval=$?;;
 'GracefullyFinishing')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "G" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"G")-1}' < \"$cache\"`"
 	rval=$?;;
 'IdleCleanupOfWorker')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "I" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"I")-1}' < \"$cache\"`"
 	rval=$?;;
 'OpenSlotWithNoCurrentProcess')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "." }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,".")-1}' < \"$cache\"`"
 	rval=$?;;
 *)
 	usage

--- a/zapache
+++ b/zapache
@@ -150,7 +150,7 @@ case "$CASE_VALUE" in
 	value="`awk '/^IdleWorkers:/ {print $2}' < \"$cache\"`"
 	rval=$?;;
 'WaitingForConnection')
-	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "_" }; { print NF-1 }'`"
+	value="`awk '/^Scoreboard:/ {print split($2,notused,"_")-1}' < \"$cache\"
 	rval=$?;;
 'StartingUp')
 	value="`awk '/^Scoreboard:/ {print $2}' < \"$cache\" | awk 'BEGIN { FS = "S" }; { print NF-1 }'`"


### PR DESCRIPTION
I think it will be faster to use one awk call with 'split' function then two separate awk calls.