### PR TITLE
fixed ping response if fetching the status page return a error status code

### DIFF
--- a/zapache
+++ b/zapache
@@ -101,7 +101,11 @@ if [ "$cache" -ot "$cache_timestamp_check" ]; then
 	fetch_url "$STATUS_URL" > "$cache"
 	rval=$?
 	if [ $rval != 0 ]; then
-		echo "ZBX_NOTSUPPORTED"
+		if [ "$CASE_VALUE" == "ping" ]; then
+			echo "0"
+		else
+			echo "ZBX_NOTSUPPORTED"
+		fi
 		exit 1
 	fi
 fi


### PR DESCRIPTION
Hi guys,
I noted that when apache is stopped, the first time that zapache is called return a "ZBX_NOTSUPPORTED" even on ping, but the second time that is invoked it returns correctly "0".
The "ZBX_NOTSUPPORTED" generate a delay in Zabbix, so the trigger will fire too late, so i fixed adding a special case inside the control of the return status code of the fetching function.
