### PR TITLE
Fix double output bug in Apache 2.4

### DIFF
--- a/zapache
+++ b/zapache
@@ -98,7 +98,7 @@ if [ "$cache" -ot "$cache_timestamp_check" ]; then
 		fi
 	fi
 
-	fetch_url "$STATUS_URL" > "$cache"
+	fetch_url "$STATUS_URL" | sort -u > "$cache"
 	rval=$?
 	if [ $rval != 0 ]; then
 		echo "ZBX_NOTSUPPORTED"


### PR DESCRIPTION
Sometimes Apache 2.4 has some entries double, this fixes it